### PR TITLE
Fix typo in Singapore's meetup location

### DIFF
--- a/docs/find/README.md
+++ b/docs/find/README.md
@@ -20,7 +20,7 @@ In order to help preserve the integrity of the Vue.js community, this page will 
 
 * Bangalore - [Vue Bangalore | VueBLR](https://meetup.com/vue-bangalore)
 
-### Malaysia
+### Singapore
 
 * Singapore - [Vue JS Singapore](https://meetup.com/Vue-JS-Singapore)
 


### PR DESCRIPTION
Vue JS Singapore is held in Singapore, not Malaysia.