### PR TITLE
Add Wellington.vue meetup

### DIFF
--- a/docs/find/README.md
+++ b/docs/find/README.md
@@ -180,6 +180,12 @@ And if you haven't heard of it, check out [VuePeople](https://vuepeople.org) to 
 - Washington D.C.
   - DC Metro Area - [Vue DC](https://meetup.com/Vue-DC)
 
+## Pacific
+
+### New Zealand
+
+- Wellington - [Wellington.vue](https://www.meetup.com/Wellington-vue/)
+
 ## South America
 
 ### Brazil


### PR DESCRIPTION
New Zealand doesn't belong under Australia, so I've followed timezone namespacing and put us under `Pacific`. Alternatively they could be lumped together under [Oceania](https://en.wikipedia.org/wiki/Oceania).