### PR TITLE
Removed the London Vue User Group

### DIFF
--- a/docs/find/README.md
+++ b/docs/find/README.md
@@ -127,7 +127,6 @@ And if you haven't heard of it, check out [VuePeople](https://vuepeople.org) to 
 ### United Kingdom
 
 - London - [London VueJS Meetup](https://meetup.com/London-Vue-js-Meetup)
-- London - [London Vue User Group](https://meetup.com/london-vue-user-group)
 - Manchester - [VueJS Manchester Community](https://www.meetup.com/VueJS-Manchester/)
 
 ## North America


### PR DESCRIPTION
The link was dead an redirected back to the Meetup.com homepage, it seems as though the Meetup is no longer active