### PR TITLE
Filter events depending on type

### DIFF
--- a/docs/.vuepress/components/EventsList.vue
+++ b/docs/.vuepress/components/EventsList.vue
@@ -8,13 +8,14 @@
 				:key="option.value"
 				class="events-list__filter"
 				:class="{ 'is-active': type === option.value }">
-				{{ option.label }}
 				<input
 					type="radio"
 					v-model="type"
 					:value="option.value"
-					class="events-list__input"
-				>
+					class="events-list__input">
+				<span class="events-list__label-text">
+					{{ option.label }}
+				</span>
 			</label>
 		</div>
 
@@ -63,6 +64,10 @@ export default {
 	position: absolute;
 	opacity: 0;
 	z-index: -1;
+}
+
+.events-list__input:focus + .events-list__label-text {
+	outline-style: auto;
 }
 
 .events-list__filter {

--- a/docs/.vuepress/components/EventsList.vue
+++ b/docs/.vuepress/components/EventsList.vue
@@ -1,43 +1,21 @@
 <template>
 	<div>
-		<h2>Filter by: </h2>
 		<div class="events-list__filters">
 			<span>Show:</span>
-			<input
-				type="radio"
-				v-model="type"
-				id="all"
-				value=""
-				class="events-list__input"
-			>
-			<label
-				for="all"
-				class="events-list__filter"
-				:class="{ 'is-active': this.type === '' }">All</label>
 
-			<input
-				type="radio"
-				v-model="type"
-				id="meetup"
-				value="meetup"
-				class="events-list__input"
-			>
 			<label
-				for="meetup"
+				v-for="option in typesOptions"
+				:key="option.value"
 				class="events-list__filter"
-				:class="{ 'is-active': this.type === 'meetup' }">Meetups</label>
-
-			<input
-				type="radio"
-				v-model="type"
-				id="conference"
-				value="conference"
-				class="events-list__input"
-			>
-			<label
-				for="conference"
-				class="events-list__filter"
-				:class="{ 'is-active': this.type === 'conference' }">Conference</label>
+				:class="{ 'is-active': type === option.value }">
+				{{ option.label }}
+				<input
+					type="radio"
+					v-model="type"
+					:value="option.value"
+					class="events-list__input"
+				>
+			</label>
 		</div>
 
 		<events-timeline :type="type">
@@ -58,15 +36,27 @@
 export default {
 	data() {
 		return {
-			type: ''
+			type: '',
+			typesOptions: [{
+				value: '',
+				label: 'All',
+			}, {
+				value: 'meetup',
+				label: 'Meetups',
+			}, {
+				value: 'conference',
+				label: 'Conference',
+			}]
 		}
-	}
+	},
 }
 </script>
 
 <style>
 .events-list__filters {
-	margin: 2rem 0;
+	padding: 3rem 0;
+	border-top: 1px solid #eaecef;
+	margin-top: 3rem;
 }
 
 .events-list__input {
@@ -77,13 +67,12 @@ export default {
 
 .events-list__filter {
 	font-weight: 500;
-	color: #3eaf7c;
 	cursor: pointer;
 	margin: 0 1.5rem;
 }
 
 .events-list__filter:hover,
 .events-list__filter.is-active {
-	text-decoration: underline;
+	color: #3eaf7c;
 }
 </style>

--- a/docs/.vuepress/components/EventsList.vue
+++ b/docs/.vuepress/components/EventsList.vue
@@ -1,0 +1,89 @@
+<template>
+	<div>
+		<h2>Filter by: </h2>
+		<div class="events-list__filters">
+			<span>Show:</span>
+			<input
+				type="radio"
+				v-model="type"
+				id="all"
+				value=""
+				class="events-list__input"
+			>
+			<label
+				for="all"
+				class="events-list__filter"
+				:class="{ 'is-active': this.type === '' }">All</label>
+
+			<input
+				type="radio"
+				v-model="type"
+				id="meetup"
+				value="meetup"
+				class="events-list__input"
+			>
+			<label
+				for="meetup"
+				class="events-list__filter"
+				:class="{ 'is-active': this.type === 'meetup' }">Meetups</label>
+
+			<input
+				type="radio"
+				v-model="type"
+				id="conference"
+				value="conference"
+				class="events-list__input"
+			>
+			<label
+				for="conference"
+				class="events-list__filter"
+				:class="{ 'is-active': this.type === 'conference' }">Conference</label>
+		</div>
+
+		<events-timeline :type="type">
+
+			<slot name="upcoming"></slot>
+
+		</events-timeline>
+
+		<events-timeline :past="true" :type="type">
+
+			<slot name="past"></slot>
+
+		</events-timeline>
+	</div>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			type: ''
+		}
+	}
+}
+</script>
+
+<style>
+.events-list__filters {
+	margin: 2rem 0;
+}
+
+.events-list__input {
+	position: absolute;
+	opacity: 0;
+	z-index: -1;
+}
+
+.events-list__filter {
+	font-weight: 500;
+	color: #3eaf7c;
+	cursor: pointer;
+	margin: 0 1.5rem;
+}
+
+.events-list__filter:hover,
+.events-list__filter.is-active {
+	text-decoration: underline;
+}
+</style>

--- a/docs/.vuepress/components/EventsTimeline.vue
+++ b/docs/.vuepress/components/EventsTimeline.vue
@@ -49,6 +49,7 @@ export default {
 
  			Object.keys(eventsTimeline).forEach((year) => {
 				Object.keys(eventsTimeline[year]).forEach((month) => {
+					eventsTimeline[year][month].sort((e1, e2) => new Date(e1.startDate) - new Date(e2.startDate));
 					eventsTimeline[year][month].forEach((event) => {
 						if (this.showEvent(event)) {
 							if (!events[year]) {

--- a/docs/.vuepress/components/EventsTimeline.vue
+++ b/docs/.vuepress/components/EventsTimeline.vue
@@ -36,7 +36,11 @@ export default {
 		past: {
 			type: Boolean,
 			default: false
-		}
+		},
+		type: {
+			type: String,
+			default: '',
+		},
 	},
 
 	computed: {
@@ -46,7 +50,7 @@ export default {
  			Object.keys(eventsTimeline).forEach((year) => {
 				Object.keys(eventsTimeline[year]).forEach((month) => {
 					eventsTimeline[year][month].forEach((event) => {
-						if (isPast(event.endDate) === this.past) {
+						if (this.showEvent(event)) {
 							if (!events[year]) {
 								events[year] = {};
 							}
@@ -62,6 +66,15 @@ export default {
 			return events;
 		}
 	},
+
+	methods: {
+		showEvent(event) {
+			const checkDate = isPast(event.endDate) === this.past;
+			const checkType = (this.type) ? this.type === event.type : true;
+
+			return checkDate && checkType;
+		}
+	}
 }
 </script>
 

--- a/docs/.vuepress/data/2018.json
+++ b/docs/.vuepress/data/2018.json
@@ -1469,10 +1469,9 @@
 			"type": "meetup"
 		},
 		{
-			"date": "14th",
-			"time": "at 16th",
+			"date": "14th-16th",
 			"startDate": "2018-11-14",
-			"endDate": "2018-11-14",
+			"endDate": "2018-11-16",
 			"organiser": "Vue Toronto",
 			"organiserLink": "https://www.meetup.com/Vue-Toronto/",
 			"name": "VueConf TO",

--- a/docs/events/README.md
+++ b/docs/events/README.md
@@ -12,17 +12,17 @@ Be sure to use [#vuemeetups](https://twitter.com/hashtag/vuemeetups) to make sur
 
 To add yours to the list, please [open an issue](https://github.com/bencodezen/vue-meetups/issues/new) or submit a PR to the [repo](https://github.com/bencodezen/vue-meetups/edit/master/docs/events/README.md).
 
-<events-timeline>
+<events-list>
+<template slot="upcoming">
 
 ## Upcoming
 
 For upcoming [VueVixen](https://vuevixens.org) events, be sure to bookmark [https://vuevixens.org/upcoming](https://vuevixens.org/upcoming)!
 
-</events-timeline>
-
-
-<events-timeline :past="true">
+</template>
+<template slot="past">
 
 ## Past
 
-</events-timeline>
+</template>
+</events-list>


### PR DESCRIPTION
This introduces a simple filter depending on the type of events.
 - Filter per type
 - Sort events depending on start date rather than depending on JSON order 

It should be the last step to close #4 I think

Preview

![event-filter](https://user-images.githubusercontent.com/17130395/47676213-e6a4f780-dbb3-11e8-9477-73de74569c01.jpeg)
