### PR TITLE
add active Dublin meetup

### DIFF
--- a/docs/find/README.md
+++ b/docs/find/README.md
@@ -84,7 +84,7 @@ And if you haven't heard of it, check out [VuePeople](https://vuepeople.org) to 
 
 ### Ireland
 
-- Dublin - [Vue.js Ireland](https://meetup.com/vuejs-ireland)
+- Dublin - [VueJS Dublin](https://www.meetup.com/DublinVueJS/)
 
 ### Israel
 


### PR DESCRIPTION
As there was no meetup for more than a year in https://meetup.com/vuejs-ireland and  https://www.meetup.com/DublinVueJS/ is organizing a meetup every month, I suggest to keep the latter as Dublin Vue.js meetup.