### PR TITLE
fix(filter): add missing name to input for filtering

### DIFF
--- a/docs/.vuepress/components/EventsList.vue
+++ b/docs/.vuepress/components/EventsList.vue
@@ -12,6 +12,7 @@
 					<input
 						type="radio"
 						v-model="type"
+						name="event-type"
 						:value="option.value"
 						class="events-list__input">
 					<span class="events-list__label-text">


### PR DESCRIPTION
Realised the filter was not working on the live website but was on my local. It was missing the input name and not selecting to radio value properly